### PR TITLE
Change minimum CMake version from 2.8 to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project("CSiBE")
 

--- a/gen/CMSIS/BasicMathFunctions/CMakeLists.txt
+++ b/gen/CMSIS/BasicMathFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (BasicMathFunctions)
 

--- a/gen/CMSIS/CommonTables/CMakeLists.txt
+++ b/gen/CMSIS/CommonTables/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (CommonTables)
 

--- a/gen/CMSIS/ComplexMathFunctions/CMakeLists.txt
+++ b/gen/CMSIS/ComplexMathFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (ComplexMathFunctions)
 

--- a/gen/CMSIS/ControllerFunctions/CMakeLists.txt
+++ b/gen/CMSIS/ControllerFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (ControllerFunctions)
 

--- a/gen/CMSIS/FastMathFunctions/CMakeLists.txt
+++ b/gen/CMSIS/FastMathFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (FastMathFunctions)
 

--- a/gen/CMSIS/FilteringFunctions/CMakeLists.txt
+++ b/gen/CMSIS/FilteringFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (FilteringFunctions)
 

--- a/gen/CMSIS/MatrixFunctions/CMakeLists.txt
+++ b/gen/CMSIS/MatrixFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (MatrixFunctions)
 

--- a/gen/CMSIS/StatisticsFunctions/CMakeLists.txt
+++ b/gen/CMSIS/StatisticsFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (StatisticsFunctions)
 

--- a/gen/CMSIS/SupportFunctions/CMakeLists.txt
+++ b/gen/CMSIS/SupportFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (SupportFunctions)
 

--- a/gen/CMSIS/TransformFunctions/CMakeLists.txt
+++ b/gen/CMSIS/TransformFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (TransformFunctions)
 

--- a/gen/CSiBE-v2.1.1/OpenTCP-1.0.4/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/OpenTCP-1.0.4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (OpenTCP-1.0.4)
 

--- a/gen/CSiBE-v2.1.1/bzip2-1.0.2/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/bzip2-1.0.2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (bzip2-1.0.2)
 

--- a/gen/CSiBE-v2.1.1/cg_compiler_opensrc/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/cg_compiler_opensrc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (cg_compiler_opensrc)
 

--- a/gen/CSiBE-v2.1.1/compiler/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (compiler)
 

--- a/gen/CSiBE-v2.1.1/flex-2.5.31/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/flex-2.5.31/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (flex-2.5.31)
 

--- a/gen/CSiBE-v2.1.1/jikespg-1.3/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/jikespg-1.3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (jikespg-1.3)
 

--- a/gen/CSiBE-v2.1.1/jpeg-6b/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/jpeg-6b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (jpeg-6b)
 

--- a/gen/CSiBE-v2.1.1/libmspack/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/libmspack/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (libmspack)
 

--- a/gen/CSiBE-v2.1.1/libpng-1.2.5/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/libpng-1.2.5/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (libpng-1.2.5)
 

--- a/gen/CSiBE-v2.1.1/lwip-0.5.3.preproc/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/lwip-0.5.3.preproc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (lwip-0.5.3.preproc)
 

--- a/gen/CSiBE-v2.1.1/mpeg2dec-0.3.1/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/mpeg2dec-0.3.1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (mpeg2dec-0.3.1)
 

--- a/gen/CSiBE-v2.1.1/mpgcut-1.1/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/mpgcut-1.1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (mpgcut-1.1)
 

--- a/gen/CSiBE-v2.1.1/replaypc-0.4.0.preproc/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/replaypc-0.4.0.preproc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (replaypc-0.4.0.preproc)
 

--- a/gen/CSiBE-v2.1.1/teem-1.6.0-src/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/teem-1.6.0-src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (teem-1.6.0-src)
 

--- a/gen/CSiBE-v2.1.1/ttt-0.10.1.preproc/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/ttt-0.10.1.preproc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (ttt-0.10.1.preproc)
 

--- a/gen/CSiBE-v2.1.1/unrarlib-0.4.0/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/unrarlib-0.4.0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (unrarlib-0.4.0)
 

--- a/gen/CSiBE-v2.1.1/zlib-1.1.4/CMakeLists.txt
+++ b/gen/CSiBE-v2.1.1/zlib-1.1.4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (zlib-1.1.4)
 

--- a/gen/bzip2-1.0.6/CMakeLists.txt
+++ b/gen/bzip2-1.0.6/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (bzip2-1.0.6)
 

--- a/gen/flex-2.6.0/CMakeLists.txt
+++ b/gen/flex-2.6.0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (flex-2.6.0)
 

--- a/gen/servo/CMakeLists.txt
+++ b/gen/servo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project (servo)
 


### PR DESCRIPTION
This change is needed because the add_compile_options command,
has only been available in CMake since version 2.8.12.